### PR TITLE
Harden manifest loading and add defensive icon validation

### DIFF
--- a/includes/elementor/class-spectre-icons-elementor-manifest-renderer.php
+++ b/includes/elementor/class-spectre-icons-elementor-manifest-renderer.php
@@ -289,12 +289,16 @@ if ( ! class_exists( 'Spectre_Icons_Elementor_Manifest_Renderer' ) ) :
 					if ( '' === $slug ) {
 						continue;
 					}
-					if ( is_string( $icon_entry ) ) {
+					if ( is_string( $icon_entry ) && '' !== trim( $icon_entry ) ) {
 						$icons[ $slug ] = array( 'svg' => $icon_entry );
 						continue;
 					}
 					if ( is_array( $icon_entry ) ) {
-						$icons[ $slug ] = $icon_entry;
+						$has_svg  = isset( $icon_entry['svg'] ) && is_string( $icon_entry['svg'] ) && '' !== trim( $icon_entry['svg'] );
+						$has_body = isset( $icon_entry['body'] ) && is_string( $icon_entry['body'] ) && '' !== trim( $icon_entry['body'] );
+						if ( $has_svg || $has_body ) {
+							$icons[ $slug ] = $icon_entry;
+						}
 					}
 				}
 			} else {
@@ -306,12 +310,18 @@ if ( ! class_exists( 'Spectre_Icons_Elementor_Manifest_Renderer' ) ) :
 					if ( '' === $slug ) {
 						continue;
 					}
-					if ( isset( $icon_entry['svg'] ) && is_string( $icon_entry['svg'] ) ) {
+
+					$has_svg  = isset( $icon_entry['svg'] ) && is_string( $icon_entry['svg'] ) && '' !== trim( $icon_entry['svg'] );
+					$has_body = isset( $icon_entry['body'] ) && is_string( $icon_entry['body'] ) && '' !== trim( $icon_entry['body'] );
+
+					if ( $has_svg || $has_body ) {
 						$icons[ $slug ] = $icon_entry;
-						continue;
 					}
-					$icons[ $slug ] = $icon_entry;
 				}
+			}
+
+			if ( empty( $icons ) ) {
+				self::log_debug( sprintf( 'Manifest for library "%s" contained no valid icons.', $library_slug ) );
 			}
 
 			self::$icons_cache[ $library_slug ] = $icons;

--- a/tests/phpunit/ManifestHardeningTest.php
+++ b/tests/phpunit/ManifestHardeningTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+final class ManifestHardeningTest extends Spectre_Icons_PHPUnit_Test_Case {
+
+    public function test_get_icons_filters_invalid_entries_in_associative_manifest(): void {
+        $manifest_path = $this->create_temp_manifest(
+            array(
+                'valid-svg'  => array('svg' => '<svg><path d="M0 0" /></svg>'),
+                'valid-body' => array('body' => '<path d="M1 1" />'),
+                'raw-string' => '<svg><circle cx="5" cy="5" r="5" /></svg>',
+                'empty-svg'  => array('svg' => ''),
+                'empty-body' => array('body' => ' '),
+                'no-content' => array('other' => 'data'),
+                'not-array'  => 123,
+            )
+        );
+
+        Spectre_Icons_Elementor_Manifest_Renderer::register_manifest('assoc-test', $manifest_path);
+        $slugs = Spectre_Icons_Elementor_Manifest_Renderer::get_icon_slugs('assoc-test');
+
+        $this->assertContains('valid-svg', $slugs);
+        $this->assertContains('valid-body', $slugs);
+        $this->assertContains('raw-string', $slugs);
+        $this->assertNotContains('empty-svg', $slugs);
+        $this->assertNotContains('empty-body', $slugs);
+        $this->assertNotContains('no-content', $slugs);
+        $this->assertNotContains('not-array', $slugs);
+        $this->assertCount(3, $slugs);
+    }
+
+    public function test_get_icons_filters_invalid_entries_in_indexed_manifest(): void {
+        $manifest_path = $this->create_temp_manifest(
+            array(
+                array('slug' => 'valid-svg', 'svg' => '<svg><path d="M0 0" /></svg>'),
+                array('slug' => 'valid-body', 'body' => '<path d="M1 1" />'),
+                array('slug' => 'empty-svg', 'svg' => ''),
+                array('slug' => 'empty-body', 'body' => ' '),
+                array('slug' => 'no-content', 'other' => 'data'),
+                array('no-slug' => 'data'),
+                'invalid-entry',
+            )
+        );
+
+        Spectre_Icons_Elementor_Manifest_Renderer::register_manifest('indexed-test', $manifest_path);
+        $slugs = Spectre_Icons_Elementor_Manifest_Renderer::get_icon_slugs('indexed-test');
+
+        $this->assertContains('valid-svg', $slugs);
+        $this->assertContains('valid-body', $slugs);
+        $this->assertNotContains('empty-svg', $slugs);
+        $this->assertNotContains('empty-body', $slugs);
+        $this->assertNotContains('no-content', $slugs);
+        $this->assertCount(2, $slugs);
+    }
+
+    public function test_get_icons_handles_wrapped_manifest_structure(): void {
+        $manifest_path = $this->create_temp_manifest(
+            array(
+                'icons' => array(
+                    'wrapped-icon' => array('svg' => '<svg><path d="M0 0" /></svg>'),
+                ),
+            )
+        );
+
+        Spectre_Icons_Elementor_Manifest_Renderer::register_manifest('wrapped-test', $manifest_path);
+        $slugs = Spectre_Icons_Elementor_Manifest_Renderer::get_icon_slugs('wrapped-test');
+
+        $this->assertSame(array('wrapped-icon'), $slugs);
+    }
+
+    public function test_get_icons_returns_empty_for_malformed_json(): void {
+        $path = tempnam(sys_get_temp_dir(), 'spectre-icons-bad-');
+        file_put_contents($path, '{ "unclosed": "json" ');
+
+        Spectre_Icons_Elementor_Manifest_Renderer::register_manifest('bad-json', $path);
+        $slugs = Spectre_Icons_Elementor_Manifest_Renderer::get_icon_slugs('bad-json');
+
+        $this->assertSame(array(), $slugs);
+        unlink($path);
+    }
+}


### PR DESCRIPTION
Hardened the manifest loading logic in the Elementor integration to better handle malformed or empty icon data. Key changes include:
- Strict validation of icon entries in `get_icons` (verifying `svg` or `body` content).
- Added `trim()` checks to avoid whitespace-only icon strings.
- Enhanced debug logging for manifest loading errors.
- Created `tests/phpunit/ManifestHardeningTest.php` to cover various edge cases.

This change reduces the risk of regressions or failures when processing externally generated or manually edited manifests.

---
*PR created automatically by Jules for task [4465952663600744223](https://jules.google.com/task/4465952663600744223) started by @bradpotts*