### PR TITLE
Harden SVG sanitizer and improve repo hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ yarn-error.log*
 
 # WordPress/PHP specific
 .wp-env/
+.phpunit.result.cache
 tmp-elementor
 wp-content/uploads/*
 wp-content/cache/*

--- a/includes/class-spectre-icons-svg-sanitizer.php
+++ b/includes/class-spectre-icons-svg-sanitizer.php
@@ -14,9 +14,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! class_exists( 'Spectre_Icons_SVG_Sanitizer' ) ) :
 
-		/**
-		 * Sanitizes raw SVG markup from bundled manifests for safe inline output.
-		 */
+	/**
+	 * Sanitizes raw SVG markup from bundled manifests for safe inline output.
+	 */
 	final class Spectre_Icons_SVG_Sanitizer {
 
 		/**
@@ -71,6 +71,11 @@ if ( ! class_exists( 'Spectre_Icons_SVG_Sanitizer' ) ) :
 			'y2',
 			'transform',
 			'xmlns',
+			'fill-rule',
+			'clip-rule',
+			'opacity',
+			'fill-opacity',
+			'stroke-opacity',
 			'aria-hidden',
 			'role',
 			'focusable',
@@ -114,8 +119,8 @@ if ( ! class_exists( 'Spectre_Icons_SVG_Sanitizer' ) ) :
 			$dom = new DOMDocument();
 
 			// Prevent external entity expansion attacks.
-				$dom->resolveExternals   = false; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-				$dom->substituteEntities = false; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$dom->resolveExternals   = false; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$dom->substituteEntities = false; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 			libxml_use_internal_errors( true );
 			$loaded = $dom->loadXML( $svg, LIBXML_NONET | LIBXML_NOWARNING | LIBXML_NOERROR );
@@ -125,9 +130,9 @@ if ( ! class_exists( 'Spectre_Icons_SVG_Sanitizer' ) ) :
 				return '';
 			}
 
-				self::sanitize_node_deep( $dom->documentElement ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			self::sanitize_node_deep( $dom->documentElement ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
-				$clean = $dom->saveXML( $dom->documentElement ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$clean = $dom->saveXML( $dom->documentElement ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 			return is_string( $clean ) ? $clean : '';
 		}
@@ -156,9 +161,9 @@ if ( ! class_exists( 'Spectre_Icons_SVG_Sanitizer' ) ) :
 					$remove = array();
 
 					foreach ( iterator_to_array( $node->attributes ) as $attr ) {
-							$name_raw = (string) $attr->nodeName; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-							$name     = strtolower( $name_raw );
-							$value    = strtolower( preg_replace( '/\s+/', '', (string) $attr->nodeValue ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+						$name_raw = (string) $attr->nodeName; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+						$name     = strtolower( $name_raw );
+						$value    = strtolower( preg_replace( '/\s+/', '', (string) $attr->nodeValue ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 						// Block any event handlers.
 						if ( 0 === stripos( $name_raw, 'on' ) ) {

--- a/includes/elementor/class-spectre-icons-elementor-manifest-renderer.php
+++ b/includes/elementor/class-spectre-icons-elementor-manifest-renderer.php
@@ -69,7 +69,8 @@ if ( ! class_exists( 'Spectre_Icons_Elementor_Manifest_Renderer' ) ) :
 			$slug = sanitize_key( $library_slug );
 
 			if ( '' === $slug ) {
-				self::log_debug( sprintf( 'register_manifest called with invalid library slug "%s".', (string) $library_slug ) );
+				$msg_slug = is_scalar( $library_slug ) ? (string) $library_slug : gettype( $library_slug );
+				self::log_debug( sprintf( 'register_manifest called with invalid library slug "%s".', $msg_slug ) );
 				return;
 			}
 
@@ -110,7 +111,8 @@ if ( ! class_exists( 'Spectre_Icons_Elementor_Manifest_Renderer' ) ) :
 			$slug = sanitize_key( $library_slug );
 
 			if ( '' === $slug || ! isset( self::$libraries[ $slug ] ) ) {
-				self::log_debug( sprintf( 'get_icon_slugs called for unknown library "%s".', (string) $library_slug ) );
+				$msg_slug = is_scalar( $library_slug ) ? (string) $library_slug : gettype( $library_slug );
+				self::log_debug( sprintf( 'get_icon_slugs called for unknown library "%s".', $msg_slug ) );
 				return array();
 			}
 
@@ -539,7 +541,7 @@ if ( ! class_exists( 'Spectre_Icons_Elementor_Manifest_Renderer' ) ) :
 		 */
 		private static function log_debug( $message ) {
 			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-                // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 				error_log( '[Spectre Icons][Manifest Renderer] ' . $message );
 			}
 		}

--- a/tests/phpunit/SVGSanitizerTest.php
+++ b/tests/phpunit/SVGSanitizerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+final class SVGSanitizerTest extends Spectre_Icons_PHPUnit_Test_Case {
+
+	public function test_sanitize_preserves_safe_svg_content(): void {
+		$svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-camera"><path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3l-2.5-3z"/><circle cx="12" cy="13" r="3"/></svg>';
+
+		$sanitized = Spectre_Icons_SVG_Sanitizer::sanitize( $svg );
+
+		$this->assertStringContainsString( 'viewBox="0 0 24 24"', $sanitized );
+		$this->assertStringContainsString( 'stroke="currentColor"', $sanitized );
+		$this->assertStringContainsString( '<path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3l-2.5-3z"', $sanitized );
+		$this->assertStringContainsString( '<circle cx="12" cy="13" r="3"', $sanitized );
+	}
+
+	public function test_sanitize_preserves_newly_added_safe_attributes(): void {
+		$svg = '<svg fill-rule="evenodd" clip-rule="evenodd" opacity="0.5" fill-opacity="0.8" stroke-opacity="0.9"><path d="M0 0h24v24H0z"/></svg>';
+
+		$sanitized = Spectre_Icons_SVG_Sanitizer::sanitize( $svg );
+
+		$this->assertStringContainsString( 'fill-rule="evenodd"', $sanitized );
+		$this->assertStringContainsString( 'clip-rule="evenodd"', $sanitized );
+		$this->assertStringContainsString( 'opacity="0.5"', $sanitized );
+		$this->assertStringContainsString( 'fill-opacity="0.8"', $sanitized );
+		$this->assertStringContainsString( 'stroke-opacity="0.9"', $sanitized );
+	}
+
+	public function test_sanitize_removes_dangerous_tags_and_attributes(): void {
+		$svg = '<svg onclick="alert(1)"><script>alert(2)</script><path d="M0 0h24v24H0z"/><foreignObject>Dangerous</foreignObject></svg>';
+
+		$sanitized = Spectre_Icons_SVG_Sanitizer::sanitize( $svg );
+
+		$this->assertStringNotContainsString( 'onclick=', $sanitized );
+		$this->assertStringNotContainsString( '<script', $sanitized );
+		$this->assertStringNotContainsString( '<foreignObject', $sanitized );
+		$this->assertStringContainsString( '<path d="M0 0h24v24H0z"', $sanitized );
+	}
+
+	public function test_sanitize_handles_empty_or_invalid_input(): void {
+		$this->assertSame( '', Spectre_Icons_SVG_Sanitizer::sanitize( '' ) );
+		$this->assertSame( '', Spectre_Icons_SVG_Sanitizer::sanitize( '   ' ) );
+		$this->assertSame( '', Spectre_Icons_SVG_Sanitizer::sanitize( 'not an svg' ) );
+	}
+}


### PR DESCRIPTION
This PR introduces several reliability and repo hygiene improvements:
1.  **Repo Hygiene**: Excludes PHPUnit result cache from version control.
2.  **Defensive Hardening**: Enhances the `Spectre_Icons_SVG_Sanitizer` to support common modern SVG attributes like `fill-rule` and `opacity`.
3.  **Code Quality**: Fixes indentation and whitespace issues in critical `includes` files to align with WordPress standards.
4.  **Test Stability**: Adds a dedicated PHPUnit test suite for the SVG sanitizer to ensure it correctly preserves safe content while stripping dangerous tags/attributes.
5.  **Logging Safety**: Hardens debug logging in the manifest renderer to safely handle unexpected input types.

---
*PR created automatically by Jules for task [2909109056396686608](https://jules.google.com/task/2909109056396686608) started by @bradpotts*