### PR TITLE
Harden SVG sanitization and manifest renderer reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ dist/
 
 # WordPress/PHP specific
 .wp-env/
+.phpunit.cache/
 .phpunit.result.cache
 tmp-elementor
 wp-content/uploads/*

--- a/includes/class-spectre-icons-svg-sanitizer.php
+++ b/includes/class-spectre-icons-svg-sanitizer.php
@@ -82,6 +82,8 @@ if ( ! class_exists( 'Spectre_Icons_SVG_Sanitizer' ) ) :
 			'aria-hidden',
 			'role',
 			'focusable',
+			'preserveaspectratio',
+			'overflow',
 		);
 
 		/**

--- a/includes/elementor/class-spectre-icons-elementor-manifest-renderer.php
+++ b/includes/elementor/class-spectre-icons-elementor-manifest-renderer.php
@@ -146,7 +146,9 @@ if ( ! class_exists( 'Spectre_Icons_Elementor_Manifest_Renderer' ) ) :
 			}
 
 			if ( '' === $library_slug || ! isset( self::$libraries[ $library_slug ] ) ) {
-				self::log_debug( sprintf( 'render_icon: unknown library "%s" for icon "%s".', $library_slug, $icon_slug ) );
+				$msg_lib  = is_scalar( $library_slug ) ? (string) $library_slug : gettype( $library_slug );
+				$msg_icon = is_scalar( $icon_slug ) ? (string) $icon_slug : gettype( $icon_slug );
+				self::log_debug( sprintf( 'render_icon: unknown library "%s" for icon "%s".', $msg_lib, $msg_icon ) );
 				return '';
 			}
 

--- a/tests/phpunit/SVGSanitizerTest.php
+++ b/tests/phpunit/SVGSanitizerTest.php
@@ -37,6 +37,15 @@ final class SVGSanitizerTest extends Spectre_Icons_PHPUnit_Test_Case {
 		$this->assertStringContainsString( 'vector-effect="non-scaling-stroke"', $sanitized );
 	}
 
+	public function test_sanitize_preserves_layout_attributes(): void {
+		$svg = '<svg preserveAspectRatio="xMidYMid meet" overflow="visible"><path d="M0 0h24v24H0z"/></svg>';
+
+		$sanitized = Spectre_Icons_SVG_Sanitizer::sanitize( $svg );
+
+		$this->assertStringContainsString( 'preserveAspectRatio="xMidYMid meet"', $sanitized );
+		$this->assertStringContainsString( 'overflow="visible"', $sanitized );
+	}
+
 	public function test_sanitize_removes_dangerous_tags_and_attributes(): void {
 		$svg = '<svg onclick="alert(1)"><script>alert(2)</script><path d="M0 0h24v24H0z"/><foreignObject>Dangerous</foreignObject></svg>';
 


### PR DESCRIPTION
I have implemented a set of surgical improvements to strengthen the reliability and maintainability of Spectre Icons. Key changes include expanding the SVG sanitizer's allowed attributes to include `preserveaspectratio` and `overflow`, and hardening the manifest renderer's debug logging with `is_scalar` checks to prevent potential PHP notices. I also updated the repository's `.gitignore` and added a new unit test to ensure these layout-critical SVG attributes remain protected during sanitization. All existing and new PHPUnit tests passed successfully.

---
*PR created automatically by Jules for task [10764175996908732017](https://jules.google.com/task/10764175996908732017) started by @bradpotts*