### PR TITLE
Defensive hardening for Manifest Renderer

### DIFF
--- a/includes/elementor/class-spectre-icons-elementor-manifest-renderer.php
+++ b/includes/elementor/class-spectre-icons-elementor-manifest-renderer.php
@@ -137,6 +137,10 @@ if ( ! class_exists( 'Spectre_Icons_Elementor_Manifest_Renderer' ) ) :
 		 * @return string Rendered HTML or empty string on failure.
 		 */
 		public static function render_icon( $icon, $attributes = array(), $tag = 'span' ) {
+			if ( ! is_array( $icon ) && ! is_string( $icon ) ) {
+				return '';
+			}
+
 			// Determine library + icon slug from Elementor's payload.
 			list($library_slug, $icon_slug) = self::extract_slug( $icon );
 
@@ -364,6 +368,10 @@ if ( ! class_exists( 'Spectre_Icons_Elementor_Manifest_Renderer' ) ) :
 		 * @return array{string,string} [ library_slug, icon_slug ]
 		 */
 		private static function extract_slug( $icon ) {
+			if ( ! is_array( $icon ) && ! is_string( $icon ) ) {
+				return array( '', '' );
+			}
+
 			$library_slug = '';
 			$icon_slug    = '';
 
@@ -428,9 +436,12 @@ if ( ! class_exists( 'Spectre_Icons_Elementor_Manifest_Renderer' ) ) :
 
 			$current_class = '';
 			if ( isset( $attributes['class'] ) ) {
-				$current_class = is_array( $attributes['class'] )
-					? implode( ' ', $attributes['class'] )
-					: (string) $attributes['class'];
+				if ( is_array( $attributes['class'] ) ) {
+					$scalar_classes = array_filter( $attributes['class'], 'is_scalar' );
+					$current_class  = implode( ' ', $scalar_classes );
+				} else {
+					$current_class = (string) $attributes['class'];
+				}
 			}
 
 			$class_attr = trim( $base_class . ' ' . $current_class );
@@ -470,6 +481,10 @@ if ( ! class_exists( 'Spectre_Icons_Elementor_Manifest_Renderer' ) ) :
 			$parts = array();
 
 			foreach ( $attributes as $name => $value ) {
+				if ( ! is_scalar( $value ) ) {
+					continue;
+				}
+
 				$name    = esc_attr( $name );
 				$value   = esc_attr( (string) $value );
 				$parts[] = sprintf( '%s="%s"', $name, $value );

--- a/tests/phpunit/ManifestRendererTest.php
+++ b/tests/phpunit/ManifestRendererTest.php
@@ -136,4 +136,39 @@ final class ManifestRendererTest extends Spectre_Icons_PHPUnit_Test_Case {
 			)
 		);
 	}
+
+	public function test_render_icon_handles_invalid_icon_types_gracefully(): void {
+		$this->assertSame( '', Spectre_Icons_Elementor_Manifest_Renderer::render_icon( null ) );
+		$this->assertSame( '', Spectre_Icons_Elementor_Manifest_Renderer::render_icon( 123 ) );
+		$this->assertSame( '', Spectre_Icons_Elementor_Manifest_Renderer::render_icon( true ) );
+	}
+
+	public function test_render_icon_filters_non_scalar_attributes_and_classes(): void {
+		$manifest_path = $this->create_temp_manifest(
+			array(
+				'icons' => array(
+					'test' => array( 'svg' => '<svg><path d="M0 0" /></svg>' ),
+				),
+			)
+		);
+
+		Spectre_Icons_Elementor_Manifest_Renderer::register_manifest( 'attr-test', $manifest_path );
+
+		$html = Spectre_Icons_Elementor_Manifest_Renderer::render_icon(
+			array(
+				'library' => 'attr-test',
+				'value'   => 'test',
+			),
+			array(
+				'class'     => array( 'valid-class', array( 'invalid' ), (object) array() ),
+				'data-info' => array( 'nested' ),
+				'title'     => 'Safe Title',
+			)
+		);
+
+		$this->assertStringContainsString( 'class="test valid-class"', $html );
+		$this->assertStringNotContainsString( 'invalid', $html );
+		$this->assertStringContainsString( 'title="Safe Title"', $html );
+		$this->assertStringNotContainsString( 'data-info', $html );
+	}
 }


### PR DESCRIPTION
This PR hardens the `Spectre_Icons_Elementor_Manifest_Renderer` class to be more resilient against unexpected data types passed from WordPress builders or other plugins.

Key changes:
- `render_icon` and `extract_slug` now return early if the `$icon` parameter is not a string or array.
- `prepare_attributes` now filters out non-scalar values from class arrays before joining them.
- `attributes_to_string` ignores non-scalar attribute values to prevent PHP notices.
- New unit tests in `ManifestRendererTest.php` cover these edge cases.

These changes reduce the risk of runtime errors and improve the overall stability of the icon rendering pipeline.

---
*PR created automatically by Jules for task [14840888754402721381](https://jules.google.com/task/14840888754402721381) started by @bradpotts*