### PR TITLE
Hardening: SVG Sanitizer and Repo Hygiene Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ dist/
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+*.code-workspace
 .idea
 .DS_Store
 *.suo

--- a/includes/class-spectre-icons-svg-sanitizer.php
+++ b/includes/class-spectre-icons-svg-sanitizer.php
@@ -59,6 +59,8 @@ if ( ! class_exists( 'Spectre_Icons_SVG_Sanitizer' ) ) :
 			'cx',
 			'cy',
 			'r',
+			'rx',
+			'ry',
 			'x',
 			'y',
 			'width',
@@ -102,8 +104,8 @@ if ( ! class_exists( 'Spectre_Icons_SVG_Sanitizer' ) ) :
 				return '';
 			}
 
-			// Strip anything outside the <svg>…</svg> block.
-			if ( preg_match( '/<svg[\s\S]*?<\/svg>/i', $svg, $match ) ) {
+			// Strip anything outside the <svg>…</svg> block or <svg /> self-closing tag.
+			if ( preg_match( '/<svg(?:[\s\S]*?<\/svg>|[^>]*?\/>)/i', $svg, $match ) ) {
 				$svg = $match[0];
 			} else {
 				return '';

--- a/tests/phpunit/SVGSanitizerTest.php
+++ b/tests/phpunit/SVGSanitizerTest.php
@@ -46,6 +46,24 @@ final class SVGSanitizerTest extends Spectre_Icons_PHPUnit_Test_Case {
 		$this->assertStringContainsString( 'overflow="visible"', $sanitized );
 	}
 
+	public function test_sanitize_preserves_rounded_rect_attributes(): void {
+		$svg = '<svg><rect x="0" y="0" width="10" height="10" rx="2" ry="2"/></svg>';
+
+		$sanitized = Spectre_Icons_SVG_Sanitizer::sanitize( $svg );
+
+		$this->assertStringContainsString( 'rx="2"', $sanitized );
+		$this->assertStringContainsString( 'ry="2"', $sanitized );
+	}
+
+	public function test_sanitize_handles_self_closing_svg_tag(): void {
+		$svg = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />';
+
+		$sanitized = Spectre_Icons_SVG_Sanitizer::sanitize( $svg );
+
+		$this->assertStringContainsString( '<svg', $sanitized );
+		$this->assertStringContainsString( 'viewBox="0 0 24 24"', $sanitized );
+	}
+
 	public function test_sanitize_removes_dangerous_tags_and_attributes(): void {
 		$svg = '<svg onclick="alert(1)"><script>alert(2)</script><path d="M0 0h24v24H0z"/><foreignObject>Dangerous</foreignObject></svg>';
 


### PR DESCRIPTION
This PR introduces several small but high-value hardening and hygiene improvements:

1.  **SVG Sanitizer Hardening:**
    *   Adds `rx` and `ry` to the `$allowed_attributes` allowlist in `Spectre_Icons_SVG_Sanitizer`. These attributes are essential for rendering rounded corners in several Lucide icons.
    *   Updates the `sanitize` method's regular expression to correctly detect and preserve self-closing `<svg />` tags, making the parser more robust.
2.  **Test Coverage:**
    *   Adds new test cases to `SVGSanitizerTest.php` to verify that `rx` and `ry` attributes are preserved and that self-closing `<svg />` tags are handled correctly.
3.  **Repo Hygiene:**
    *   Adds `*.code-workspace` to `.gitignore` to prevent local VS Code workspace files from being committed to the repository.

Verified via `composer test` (all 25 tests passed) and PHPCS linting.

---
*PR created automatically by Jules for task [7604714016989283226](https://jules.google.com/task/7604714016989283226) started by @bradpotts*