### PR TITLE
Harden Manifest Renderer against XSS in attributes

### DIFF
--- a/includes/elementor/class-spectre-icons-elementor-manifest-renderer.php
+++ b/includes/elementor/class-spectre-icons-elementor-manifest-renderer.php
@@ -456,8 +456,13 @@ if ( ! class_exists( 'Spectre_Icons_Elementor_Manifest_Renderer' ) ) :
 					continue;
 				}
 
-				$sanitized_name = sanitize_key( $name );
+				$sanitized_name = sanitize_key( (string) $name );
 				if ( '' === $sanitized_name ) {
+					continue;
+				}
+
+				// Block any event handlers (e.g. onclick, onmouseover).
+				if ( 0 === strpos( $sanitized_name, 'on' ) ) {
 					continue;
 				}
 
@@ -569,6 +574,10 @@ if ( ! class_exists( 'Spectre_Icons_Elementor_Manifest_Renderer' ) ) :
 		 * @return void
 		 */
 		private static function log_debug( $message ) {
+			if ( ! is_string( $message ) ) {
+				return;
+			}
+
 			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 				error_log( '[Spectre Icons][Manifest Renderer] ' . $message );

--- a/tests/phpunit/ManifestRendererTest.php
+++ b/tests/phpunit/ManifestRendererTest.php
@@ -171,4 +171,36 @@ final class ManifestRendererTest extends Spectre_Icons_PHPUnit_Test_Case {
 		$this->assertStringContainsString( 'title="Safe Title"', $html );
 		$this->assertStringNotContainsString( 'data-info', $html );
 	}
+
+	public function test_render_icon_blocks_event_handler_attributes(): void {
+		$manifest_path = $this->create_temp_manifest(
+			array(
+				'icons' => array(
+					'test' => array( 'svg' => '<svg><path d="M0 0" /></svg>' ),
+				),
+			)
+		);
+
+		Spectre_Icons_Elementor_Manifest_Renderer::register_manifest( 'xss-test', $manifest_path );
+
+		$html = Spectre_Icons_Elementor_Manifest_Renderer::render_icon(
+			array(
+				'library' => 'xss-test',
+				'value'   => 'test',
+			),
+			array(
+				'onclick'     => 'alert(1)',
+				'ONMOUSEOVER' => 'bad()',
+				'  onclick'   => 'bypass',
+				'on'          => 'valid',
+				'common'      => 'safe',
+			)
+		);
+
+		$this->assertStringNotContainsString( 'onclick', $html );
+		$this->assertStringNotContainsString( 'ONMOUSEOVER', $html );
+		$this->assertStringContainsString( 'common="safe"', $html );
+		$this->assertStringNotContainsString( 'bypass', $html );
+		$this->assertStringNotContainsString( 'on="valid"', $html );
+	}
 }


### PR DESCRIPTION
This change improves the security of icon rendering by ensuring that any attributes passed to the icon wrapper tag (e.g., from Elementor controls) are strictly checked for event handlers. The check is performed after sanitization to prevent bypasses using whitespace. It also adds a defensive check to the internal logger and includes relevant unit tests.

---
*PR created automatically by Jules for task [2508737036945604186](https://jules.google.com/task/2508737036945604186) started by @bradpotts*