### PR TITLE
Harden bootstrap, align styles, and cleanup legacy config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ reflects WordPress plugin releases for Spectre Icons.
 
 - Hardened SVG sanitizer to permit local fragment identifiers in `href` and `xlink:href` attributes.
 - Added Elementor version compatibility enforcement (3.0.0+).
+- Aligned icon style fallback logic in `integration-hooks.php` with the manifest renderer.
+- Hardened plugin bootstrap by using direct `require_once` for core includes.
+- Removed legacy `window.SpectreElementorIconsConfig` JS configuration support.
 - Updated verified WordPress compatibility to 6.7 in plugin metadata and documentation.
 - Hardened SVG sanitization regex to better handle self-closing and multi-line tags.
 - Improved attribute rendering safety in the manifest renderer.

--- a/assets/js/elementor/spectre-icons-elementor.js
+++ b/assets/js/elementor/spectre-icons-elementor.js
@@ -1,7 +1,7 @@
 (function () {
   'use strict';
 
-  const config = window.SpectreIconsElementorConfig || window.SpectreElementorIconsConfig || {};
+  const config = window.SpectreIconsElementorConfig || {};
   const libraries = config.libraries || {};
 
   const libraryIds = Object.keys(libraries);

--- a/includes/elementor/integration-hooks.php
+++ b/includes/elementor/integration-hooks.php
@@ -196,7 +196,11 @@ function spectre_icons_elementor_enqueue_icon_scripts() {
 
 		$style = isset( $def['style'] ) ? (string) $def['style'] : '';
 		if ( '' === $style ) {
-			$style = ( false !== strpos( $slug, 'lucide' ) ) ? 'outline' : 'filled';
+			if ( false !== strpos( $slug, 'lucide' ) ) {
+				$style = 'outline';
+			} elseif ( false !== strpos( $slug, 'fontawesome' ) ) {
+				$style = 'filled';
+			}
 		}
 
 		$libraries[ $slug ] = array(

--- a/spectre-icons.php
+++ b/spectre-icons.php
@@ -52,8 +52,5 @@ $spectre_icons_includes = array(
 );
 
 foreach ( $spectre_icons_includes as $spectre_icons_file ) {
-	$spectre_icons_include_path = SPECTRE_ICONS_PATH . $spectre_icons_file;
-	if ( file_exists( $spectre_icons_include_path ) ) {
-		require_once $spectre_icons_include_path;
-	}
+	require_once SPECTRE_ICONS_PATH . $spectre_icons_file;
 }


### PR DESCRIPTION
This PR introduces several reliability and maintainability improvements to the Spectre Icons plugin:

1. **Hardened Bootstrap**: The plugin bootstrap in `spectre-icons.php` now uses direct `require_once` for core files, ensuring the plugin fails loudly if essential files are missing, rather than entering an inconsistent state.
2. **Aligned Style Fallbacks**: The logic for determining default icon styles (outline vs filled) has been synchronized between the PHP renderer and the integration hooks, ensuring consistent behavior across editor and frontend.
3. **Legacy JS Cleanup**: Removed support for the legacy `window.SpectreElementorIconsConfig` variable in the Elementor integration script, narrowing the configuration surface area.
4. **Changelog Updates**: Documented these and other recent unreleased hardening improvements in `CHANGELOG.md`.

These changes strengthen the plugin's core architecture without introducing new features or modifying icon assets.

---
*PR created automatically by Jules for task [12592532288441137794](https://jules.google.com/task/12592532288441137794) started by @bradpotts*