### PR TITLE
Defensive hardening and SVG sanitization improvements

### DIFF
--- a/includes/class-spectre-icons-svg-sanitizer.php
+++ b/includes/class-spectre-icons-svg-sanitizer.php
@@ -39,6 +39,8 @@ if ( ! class_exists( 'Spectre_Icons_SVG_Sanitizer' ) ) :
 			'symbol',
 			'title',
 			'desc',
+			'clippath',
+			'mask',
 		);
 
 		/**
@@ -75,6 +77,8 @@ if ( ! class_exists( 'Spectre_Icons_SVG_Sanitizer' ) ) :
 			'xmlns',
 			'fill-rule',
 			'clip-rule',
+			'clip-path',
+			'mask',
 			'stroke-dasharray',
 			'stroke-dashoffset',
 			'stroke-miterlimit',
@@ -104,7 +108,13 @@ if ( ! class_exists( 'Spectre_Icons_SVG_Sanitizer' ) ) :
 		 * @return string Safe SVG markup (may be empty).
 		 */
 		public static function sanitize( $svg ) {
-			if ( ! is_string( $svg ) || '' === trim( $svg ) ) {
+			if ( ! is_scalar( $svg ) ) {
+				return '';
+			}
+
+			$svg = (string) $svg;
+
+			if ( '' === trim( $svg ) ) {
 				return '';
 			}
 
@@ -121,7 +131,7 @@ if ( ! class_exists( 'Spectre_Icons_SVG_Sanitizer' ) ) :
 			}
 
 			// Remove dangerous containers (best-effort pre-strip).
-			$svg = preg_replace( '/<\/?(script|foreignObject|iframe|object|embed)[^>]*>/i', '', $svg );
+			$svg = (string) preg_replace( '/<\/?(script|foreignObject|iframe|object|embed)[^>]*>/i', '', $svg );
 
 			// Remove inline event handlers (best-effort pre-strip).
 			$svg = preg_replace( '/\son[a-z]+\s*=\s*"[^"]*"/i', '', $svg );

--- a/includes/elementor/class-spectre-icons-elementor-manifest-renderer.php
+++ b/includes/elementor/class-spectre-icons-elementor-manifest-renderer.php
@@ -66,7 +66,12 @@ if ( ! class_exists( 'Spectre_Icons_Elementor_Manifest_Renderer' ) ) :
 		 * @return void
 		 */
 		public static function register_manifest( $library_slug, $manifest_path, array $args = array() ) {
-			$slug = sanitize_key( $library_slug );
+			if ( ! is_scalar( $library_slug ) ) {
+				self::log_debug( sprintf( 'register_manifest called with non-scalar library slug: %s.', gettype( $library_slug ) ) );
+				return;
+			}
+
+			$slug = sanitize_key( (string) $library_slug );
 
 			if ( '' === $slug ) {
 				$msg_slug = is_scalar( $library_slug ) ? (string) $library_slug : gettype( $library_slug );
@@ -108,7 +113,11 @@ if ( ! class_exists( 'Spectre_Icons_Elementor_Manifest_Renderer' ) ) :
 		 * @return array<string>       Icon slugs (may be empty).
 		 */
 		public static function get_icon_slugs( $library_slug ) {
-			$slug = sanitize_key( $library_slug );
+			if ( ! is_scalar( $library_slug ) ) {
+				return array();
+			}
+
+			$slug = sanitize_key( (string) $library_slug );
 
 			if ( '' === $slug || ! isset( self::$libraries[ $slug ] ) ) {
 				$msg_slug = is_scalar( $library_slug ) ? (string) $library_slug : gettype( $library_slug );
@@ -409,9 +418,15 @@ if ( ! class_exists( 'Spectre_Icons_Elementor_Manifest_Renderer' ) ) :
 
 					$icon_slug = sanitize_key( $slug );
 				}
-			} elseif ( is_string( $icon ) ) {
-				// When called manually with a slug string.
-				$icon_slug = sanitize_key( $icon );
+			} elseif ( is_string( $icon ) && '' !== trim( $icon ) ) {
+				// When called manually with a slug string or space-separated library/slug string.
+				$parts = preg_split( '/\s+/', trim( $icon ) );
+				if ( count( $parts ) > 1 ) {
+					$library_slug = sanitize_key( $parts[0] );
+					$icon_slug    = sanitize_key( end( $parts ) );
+				} else {
+					$icon_slug = sanitize_key( $parts[0] );
+				}
 			}
 
 			// Strip library prefix if Elementor stored a prefixed slug.
@@ -587,9 +602,11 @@ if ( ! class_exists( 'Spectre_Icons_Elementor_Manifest_Renderer' ) ) :
 		 * @return void
 		 */
 		private static function log_debug( $message ) {
-			if ( ! is_string( $message ) ) {
+			if ( ! is_scalar( $message ) ) {
 				return;
 			}
+
+			$message = (string) $message;
 
 			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log

--- a/tests/phpunit/ManifestRendererTest.php
+++ b/tests/phpunit/ManifestRendererTest.php
@@ -276,4 +276,33 @@ final class ManifestRendererTest extends Spectre_Icons_PHPUnit_Test_Case {
 		);
 		$this->assertStringContainsString( '<svg', $html );
 	}
+
+	public function test_extract_slug_handles_space_separated_string_input(): void {
+		$manifest_path = $this->create_temp_manifest(
+			array(
+				'icons' => array(
+					'camera' => array( 'svg' => '<svg><path d="M0 0" /></svg>' ),
+				),
+			)
+		);
+
+		Spectre_Icons_Elementor_Manifest_Renderer::register_manifest( 'space-test', $manifest_path );
+
+		// Test space-separated string.
+		$html = Spectre_Icons_Elementor_Manifest_Renderer::render_icon( 'space-test camera' );
+		$this->assertStringContainsString( '<svg', $html );
+
+		// Test single slug (unknown library).
+		$this->assertSame( '', Spectre_Icons_Elementor_Manifest_Renderer::render_icon( 'camera' ) );
+	}
+
+	public function test_register_manifest_handles_invalid_slug_types(): void {
+		// Non-scalar should return early.
+		Spectre_Icons_Elementor_Manifest_Renderer::register_manifest( array( 'not' => 'scalar' ), '/path' );
+		$this->assertSame( array(), Spectre_Icons_Elementor_Manifest_Renderer::get_icon_slugs( 'not-scalar' ) );
+	}
+
+	public function test_get_icon_slugs_handles_invalid_slug_types(): void {
+		$this->assertSame( array(), Spectre_Icons_Elementor_Manifest_Renderer::get_icon_slugs( array( 'invalid' ) ) );
+	}
 }

--- a/tests/phpunit/SVGSanitizerTest.php
+++ b/tests/phpunit/SVGSanitizerTest.php
@@ -171,4 +171,22 @@ final class SVGSanitizerTest extends Spectre_Icons_PHPUnit_Test_Case {
 		$this->assertStringNotContainsString( 'data:', $sanitized );
 		$this->assertStringContainsString( '<path d="M0 0"', $sanitized );
 	}
+
+	public function test_sanitize_preserves_clippath_and_mask(): void {
+		$svg = '<svg><defs><clipPath id="cp"><rect width="10" height="10"/></clipPath><mask id="m"><circle r="5"/></mask></defs><g clip-path="url(#cp)" mask="url(#m)"><path d="M0 0h20v20H0z"/></g></svg>';
+
+		$sanitized = Spectre_Icons_SVG_Sanitizer::sanitize( $svg );
+
+		$this->assertStringContainsString( '<clippath', strtolower( $sanitized ) );
+		$this->assertStringContainsString( '<mask', strtolower( $sanitized ) );
+		$this->assertStringContainsString( 'clip-path="url(#cp)"', $sanitized );
+		$this->assertStringContainsString( 'mask="url(#m)"', $sanitized );
+	}
+
+	public function test_sanitize_handles_non_string_scalar_input(): void {
+		$this->assertSame( '', Spectre_Icons_SVG_Sanitizer::sanitize( null ) );
+		$this->assertSame( '', Spectre_Icons_SVG_Sanitizer::sanitize( array() ) );
+		// A number that doesn't look like SVG should return empty.
+		$this->assertSame( '', Spectre_Icons_SVG_Sanitizer::sanitize( 123 ) );
+	}
 }


### PR DESCRIPTION
This PR focuses on improving the defensive posture of the Spectre Icons plugin by hardening core rendering and sanitization logic.

Key improvements:
1.  **Defensive Type Checking**: Added `is_scalar()` checks to `Spectre_Icons_Elementor_Manifest_Renderer` and `Spectre_Icons_SVG_Sanitizer` to handle unexpected data types gracefully and prevent PHP warnings.
2.  **Expanded SVG Support**: Updated the `Spectre_Icons_SVG_Sanitizer` to permit `clippath`, `mask`, and `clip-path` attributes. This ensures that icons using these common SVG features render correctly without being stripped.
3.  **Flexible Rendering**: Improved `render_icon` to support space-separated library and icon slugs in a single string, providing better developer ergonomics.
4.  **Robust Logging**: Hardened internal debug logging to safely handle non-string inputs.
5.  **Test Coverage**: Added new unit tests to `ManifestRendererTest.php` and `SVGSanitizerTest.php` to verify these hardening measures and ensure no regressions.

These changes align with the goal of making the plugin more reliable and safer for automated contributions without expanding its product scope.

---
*PR created automatically by Jules for task [15974164594653813920](https://jules.google.com/task/15974164594653813920) started by @bradpotts*