### PR TITLE
Harden debug logging and align WordPress compatibility metadata

### DIFF
--- a/includes/elementor/class-spectre-icons-elementor-manifest-renderer.php
+++ b/includes/elementor/class-spectre-icons-elementor-manifest-renderer.php
@@ -603,7 +603,7 @@ if ( ! class_exists( 'Spectre_Icons_Elementor_Manifest_Renderer' ) ) :
 		 */
 		private static function log_debug( $message ) {
 			if ( ! is_scalar( $message ) ) {
-				return;
+				$message = sprintf( 'Non-scalar message type: %s', gettype( $message ) );
 			}
 
 			$message = (string) $message;

--- a/spectre-icons.php
+++ b/spectre-icons.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Plugin Name: Spectre Icons
  * Plugin URI: https://github.com/phcdevworks/spectre-icons
@@ -14,7 +13,7 @@
  * Domain Path: /languages
  * Requires at least: 6.0
  * Requires PHP: 7.4
- * Tested up to: 6.8.1
+ * Tested up to: 6.7
  *
  * @package SpectreIcons
  */


### PR DESCRIPTION
This PR introduces small but valuable maintenance improvements:
1. **Defensive Hardening**: The `log_debug` method in the manifest renderer now handles non-scalar input by logging the value's type instead of returning early. This prevents silent failures during debugging.
2. **Metadata Alignment**: The WordPress "Tested up to" version in the main plugin file is synchronized to 6.7 to match `readme.txt` and `.wordpress-org/README.md`.
3. **Linting Fix**: A minor PHPCS violation regarding the file header in `spectre-icons.php` is resolved.

These changes strengthen the repository's reliability and hygiene without expanding the plugin's scope or altering bundled assets.

---
*PR created automatically by Jules for task [12774181790615422801](https://jules.google.com/task/12774181790615422801) started by @bradpotts*